### PR TITLE
Add optional creation of Bitbucket tasks for violation comments.

### DIFF
--- a/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/BitbucketServerCommentsProvider.java
+++ b/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/BitbucketServerCommentsProvider.java
@@ -88,7 +88,12 @@ public class BitbucketServerCommentsProvider implements CommentsProvider {
   @Override
   public void createSingleFileComment(
       final ChangedFile file, final Integer line, final String comment) {
-    client.pullRequestComment(file.getFilename(), line, comment);
+    final BitbucketServerComment bitbucketComment =
+        client.pullRequestComment(file.getFilename(), line, comment);
+
+    if (violationCommentsToBitbucketApi.getCreateSingleFileCommentsTasks()) {
+      client.commentCreateTask(bitbucketComment, file.getFilename(), line);
+    }
   }
 
   @Override

--- a/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/ViolationCommentsToBitbucketServerApi.java
+++ b/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/ViolationCommentsToBitbucketServerApi.java
@@ -24,6 +24,7 @@ public class ViolationCommentsToBitbucketServerApi {
   private String bitbucketServerUrl = null;
   private boolean createCommentWithAllSingleFileComments = false;
   private boolean createSingleFileComments = true;
+  private boolean createSingleFileCommentsTasks = false;
   private String password;
   private String projectKey;
   private String propPassword = DEFAULT_PROP_VIOLATIONS_PASSWORD;
@@ -90,6 +91,10 @@ public class ViolationCommentsToBitbucketServerApi {
 
   public boolean getCreateSingleFileComments() {
     return createSingleFileComments;
+  }
+
+  public boolean getCreateSingleFileCommentsTasks() {
+    return createSingleFileCommentsTasks;
   }
 
   public String getPassword() {
@@ -191,6 +196,12 @@ public class ViolationCommentsToBitbucketServerApi {
   public ViolationCommentsToBitbucketServerApi withCreateSingleFileComments(
       final boolean createSingleFileComments) {
     this.createSingleFileComments = createSingleFileComments;
+    return this;
+  }
+
+  public ViolationCommentsToBitbucketServerApi withCreateSingleFileCommentsTasks(
+      final boolean createSingleFileCommentsTasks) {
+    this.createSingleFileCommentsTasks = createSingleFileCommentsTasks;
     return this;
   }
 


### PR DESCRIPTION
This feature optionally adds a task in Bitbucket to every violation comment, which is created on the pull request.
In combination with the Bitbucket merge check "No incomplete tasks" merges of pull requests are blocked as long as the violations are not resolved.