### PR TITLE
Fix automatic removal of violation comments

### DIFF
--- a/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/BitbucketServerClient.java
+++ b/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/BitbucketServerClient.java
@@ -11,11 +11,14 @@ import com.google.gson.Gson;
 import com.jayway.jsonpath.JsonPath;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import net.minidev.json.JSONArray;
 import se.bjurr.violations.comments.bitbucketserver.lib.client.BitbucketServerInvoker.Method;
 import se.bjurr.violations.comments.bitbucketserver.lib.client.model.BitbucketServerComment;
 import se.bjurr.violations.comments.bitbucketserver.lib.client.model.BitbucketServerDiffResponse;
+import se.bjurr.violations.comments.bitbucketserver.lib.client.model.BitbucketServerTask;
 import se.bjurr.violations.comments.lib.ViolationsLogger;
 
 public class BitbucketServerClient {
@@ -171,6 +174,15 @@ public class BitbucketServerClient {
     return toBitbucketServerComment(parsed);
   }
 
+  public BitbucketServerComment pullRequestComment(final Long commentId) {
+    String url = getBitbucketServerPullRequestBase() + "/comments/" + commentId;
+
+    final LinkedHashMap<?, ?> parsed =
+        invokeAndParse(url, BitbucketServerInvoker.Method.GET, null, "$");
+
+    return toBitbucketServerComment(parsed);
+  }
+
   public List<BitbucketServerComment> pullRequestComments(final String changedFile) {
     try {
       final String encodedChangedFile = encode(changedFile, UTF_8.name());
@@ -228,6 +240,13 @@ public class BitbucketServerClient {
         null);
   }
 
+  public void removeTask(final BitbucketServerTask task) {
+    doInvokeUrl(
+        getBitbucketServerApiBase() + "/tasks/" + task.getId(),
+        BitbucketServerInvoker.Method.DELETE,
+        null);
+  }
+
   public void commentCreateTask(
       final BitbucketServerComment comment, String changedFile, int line) {
     final String changedFileName = new File(changedFile).getName();
@@ -263,6 +282,47 @@ public class BitbucketServerClient {
     final String text = (String) parsed.get("text");
     final Integer id = (Integer) parsed.get("id");
 
-    return new BitbucketServerComment(version, text, id);
+    final JSONArray jsonArrayTasks = (JSONArray) parsed.get("tasks");
+    final JSONArray jsonArraySubComments = (JSONArray) parsed.get("comments");
+
+    List<LinkedHashMap<?, ?>> tasks = new ArrayList<>();
+    List<LinkedHashMap<?, ?>> subComments = new ArrayList<>();
+
+    for (Object jsonArrayTask : jsonArrayTasks) {
+      LinkedHashMap<?, ?> linkedHashMap = (LinkedHashMap<?, ?>) jsonArrayTask;
+      tasks.add(linkedHashMap);
+    }
+
+    for (Object jsonArraySubComment : jsonArraySubComments) {
+      LinkedHashMap<?, ?> linkedHashMap = (LinkedHashMap<?, ?>) jsonArraySubComment;
+      subComments.add(linkedHashMap);
+    }
+
+    final List<BitbucketServerTask> bitbucketServerTasks = toBitbucketServerTasks(tasks);
+    final List<BitbucketServerComment> bitbucketServerSubComments =
+        toBitbucketServerComments(subComments);
+
+    BitbucketServerComment constructedComment = new BitbucketServerComment(version, text, id);
+
+    constructedComment.setTasks(bitbucketServerTasks);
+    constructedComment.setComments(bitbucketServerSubComments);
+
+    return constructedComment;
+  }
+
+  private BitbucketServerTask toBitbucketServerTask(LinkedHashMap<?, ?> parsed) {
+    final Integer id = (Integer) parsed.get("id");
+    final String text = (String) parsed.get("text");
+    return new BitbucketServerTask(id, text);
+  }
+
+  private List<BitbucketServerTask> toBitbucketServerTasks(List<LinkedHashMap<?, ?>> parsed) {
+    List<BitbucketServerTask> bitbucketServerTasks = new ArrayList<>();
+
+    for (LinkedHashMap<?, ?> parsedTask : parsed) {
+      bitbucketServerTasks.add(toBitbucketServerTask(parsedTask));
+    }
+
+    return bitbucketServerTasks;
   }
 }

--- a/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/BitbucketServerClient.java
+++ b/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/BitbucketServerClient.java
@@ -12,6 +12,7 @@ import com.jayway.jsonpath.JsonPath;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import net.minidev.json.JSONArray;
@@ -285,35 +286,21 @@ public class BitbucketServerClient {
     final JSONArray jsonArrayTasks = (JSONArray) parsed.get("tasks");
     final JSONArray jsonArraySubComments = (JSONArray) parsed.get("comments");
 
-    List<LinkedHashMap<?, ?>> tasks = new ArrayList<>();
-    List<LinkedHashMap<?, ?>> subComments = new ArrayList<>();
-
-    for (Object jsonArrayTask : jsonArrayTasks) {
-      LinkedHashMap<?, ?> linkedHashMap = (LinkedHashMap<?, ?>) jsonArrayTask;
-      tasks.add(linkedHashMap);
-    }
-
-    for (Object jsonArraySubComment : jsonArraySubComments) {
-      LinkedHashMap<?, ?> linkedHashMap = (LinkedHashMap<?, ?>) jsonArraySubComment;
-      subComments.add(linkedHashMap);
-    }
+    final List<LinkedHashMap<?, ?>> tasks =
+        Arrays.asList(jsonArrayTasks.toArray(new LinkedHashMap<?, ?>[0]));
+    final List<LinkedHashMap<?, ?>> subComments =
+        Arrays.asList(jsonArraySubComments.toArray(new LinkedHashMap<?, ?>[0]));
 
     final List<BitbucketServerTask> bitbucketServerTasks = toBitbucketServerTasks(tasks);
     final List<BitbucketServerComment> bitbucketServerSubComments =
         toBitbucketServerComments(subComments);
 
-    BitbucketServerComment constructedComment = new BitbucketServerComment(version, text, id);
+    final BitbucketServerComment comment = new BitbucketServerComment(version, text, id);
 
-    constructedComment.setTasks(bitbucketServerTasks);
-    constructedComment.setComments(bitbucketServerSubComments);
+    comment.setTasks(bitbucketServerTasks);
+    comment.setComments(bitbucketServerSubComments);
 
-    return constructedComment;
-  }
-
-  private BitbucketServerTask toBitbucketServerTask(LinkedHashMap<?, ?> parsed) {
-    final Integer id = (Integer) parsed.get("id");
-    final String text = (String) parsed.get("text");
-    return new BitbucketServerTask(id, text);
+    return comment;
   }
 
   private List<BitbucketServerTask> toBitbucketServerTasks(List<LinkedHashMap<?, ?>> parsed) {
@@ -324,5 +311,11 @@ public class BitbucketServerClient {
     }
 
     return bitbucketServerTasks;
+  }
+
+  private BitbucketServerTask toBitbucketServerTask(LinkedHashMap<?, ?> parsed) {
+    final Integer id = (Integer) parsed.get("id");
+    final String text = (String) parsed.get("text");
+    return new BitbucketServerTask(id, text);
   }
 }

--- a/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/model/BitbucketServerComment.java
+++ b/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/model/BitbucketServerComment.java
@@ -1,21 +1,30 @@
 package se.bjurr.violations.comments.bitbucketserver.lib.client.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class BitbucketServerComment {
 
   private final Integer id;
   private final String text;
   private final Integer version;
+  private List<BitbucketServerTask> tasks;
+  private List<BitbucketServerComment> comments;
 
   public BitbucketServerComment() {
     this.id = null;
     this.text = null;
     this.version = null;
+    this.tasks = null;
+    this.comments = null;
   }
 
   public BitbucketServerComment(Integer version, String text, Integer id) {
     this.version = version;
     this.text = text;
     this.id = id;
+    this.tasks = new ArrayList<>();
+    this.comments = new ArrayList<>();
   }
 
   public Integer getId() {
@@ -28,5 +37,21 @@ public class BitbucketServerComment {
 
   public Integer getVersion() {
     return this.version;
+  }
+
+  public List<BitbucketServerTask> getTasks() {
+    return tasks;
+  }
+
+  public List<BitbucketServerComment> getComments() {
+    return comments;
+  }
+
+  public void setTasks(List<BitbucketServerTask> tasks) {
+    this.tasks = tasks;
+  }
+
+  public void setComments(List<BitbucketServerComment> comments) {
+    this.comments = comments;
   }
 }

--- a/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/model/BitbucketServerTask.java
+++ b/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/model/BitbucketServerTask.java
@@ -1,0 +1,20 @@
+package se.bjurr.violations.comments.bitbucketserver.lib.client.model;
+
+public class BitbucketServerTask {
+  private final Integer id;
+
+  private final String text;
+
+  public BitbucketServerTask(Integer id, String text) {
+    this.text = text;
+    this.id = id;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public String getText() {
+    return text;
+  }
+}


### PR DESCRIPTION
If a task or sub-comment has been created on a violation comment, this comment could not be automatically deleted anymore.
This is especially a problem if the option to automatically create a task on each violation comment is enabled.

* Add removal of tasks before a comment is deleted.
* Add removal of sub-comments before a comment is deleted.