### PR TITLE
[TC-2481] Add retrieval of outdated pull request comments.

### DIFF
--- a/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/BitbucketServerClient.java
+++ b/src/main/java/se/bjurr/violations/comments/bitbucketserver/lib/client/BitbucketServerClient.java
@@ -191,7 +191,7 @@ public class BitbucketServerClient {
           getBitbucketServerPullRequestBase()
               + "/comments?path="
               + encodedChangedFile
-              + "&limit=999999";
+              + "&limit=999999&anchorState=ALL";
       String jsonPath = "$.values[*]";
 
       final String json = doInvokeUrl(url, Method.GET, null);


### PR DESCRIPTION
Violation comments and their tasks are not deleted if the annotated
commit has been removed by a force-push because it is marked as outdated
in Bitbucket.
By additionally fetching outdated comments, outdated violation comments
can be automatically deleted if keepOldComments is not set.