### PR TITLE
Update version of Json Path to fix uncaught exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply from: project.buildscript.classLoader.getResource('main.gradle').toURI()
 
 dependencies {
  compile 'se.bjurr.violations:violation-comments-lib:1.+'
- compile 'com.jayway.jsonpath:json-path:2.0.0'
+ compile 'com.jayway.jsonpath:json-path:2.7.0'
  compile 'com.google.code.gson:gson:2.8.0'
  compile 'com.google.guava:guava:20.0'
  compile 'org.apache.httpcomponents:httpclient:4.5.5'


### PR DESCRIPTION
I'm raising this PR to fix a critical vulnerability that is picked up by XRAY. This is a dependency for [violation-comments-to-stash](https://plugins.jenkins.io/violation-comments-to-stash/#documentation) plugin which will also need updating.

As per CVE-2021-27568 there was an uncaught exception that could expose sensitive information. This gets identified by XRAY as a critical vulnerability.

@see https://nvd.nist.gov/vuln/detail/CVE-2021-27568